### PR TITLE
[2.7]Update k8s version

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -138,8 +138,8 @@ export default Ember.Component.extend(ClusterDriver, {
       rancherEnabled: false,
     },
     {
-      label: 'v1.19',
-      value: 'v1.19',
+      label: 'v1.25(Beta)',
+      value: 'v1.25',
       rancherEnabled: false,
     },
   ],


### PR DESCRIPTION
RPM 版本：v2.7.2-ent
更新 k8s 版本：由["v1.23", "v1.21", "v1.19"] 更新至 ["v1.23", "v1.21", "v1.25(Beta)"]
其中 ["v1.21", "v1.25(Beta)"] 不在 RPM 支持矩阵。